### PR TITLE
Add minimal React SPA

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# codex-testing
+# Codex React SPA
+
+This repository contains a minimal React single-page application (SPA) that can be served directly from GitHub Pages. The app includes a home page and a user settings page. All settings are saved in `localStorage` so they persist across browser sessions.
+
+## Running locally
+Open `index.html` in your browser. No build step is required because the application loads React and React Router from CDNs.
+
+## Deploying to GitHub Pages
+1. Commit the files to a GitHub repository.
+2. In the repository settings, enable GitHub Pages and choose the `main` branch (or whichever branch you use) as the source.
+3. Visit the URL provided by GitHub Pages to view the app.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,80 @@
+const { BrowserRouter, Routes, Route, Link } = ReactRouterDOM;
+
+function useLocalStorage(key, initialValue) {
+  const [value, setValue] = React.useState(() => {
+    const stored = localStorage.getItem(key);
+    return stored ? JSON.parse(stored) : initialValue;
+  });
+
+  React.useEffect(() => {
+    localStorage.setItem(key, JSON.stringify(value));
+  }, [key, value]);
+
+  return [value, setValue];
+}
+
+function Home({ settings }) {
+  return (
+    <div>
+      <h1>Home</h1>
+      <p>Welcome {settings.username || 'Guest'}!</p>
+      <p>Current theme: {settings.theme}</p>
+    </div>
+  );
+}
+
+function Settings({ settings, setSettings }) {
+  const handleChange = (e) => {
+    const { name, value } = e.target;
+    setSettings({ ...settings, [name]: value });
+  };
+
+  return (
+    <div>
+      <h1>User Settings</h1>
+      <div>
+        <label>
+          Username:
+          <input
+            name="username"
+            value={settings.username}
+            onChange={handleChange}
+          />
+        </label>
+      </div>
+      <div>
+        <label>
+          Theme:
+          <select name="theme" value={settings.theme} onChange={handleChange}>
+            <option value="light">Light</option>
+            <option value="dark">Dark</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  );
+}
+
+function App() {
+  const [settings, setSettings] = useLocalStorage('settings', {
+    username: '',
+    theme: 'light',
+  });
+
+  return (
+    <BrowserRouter>
+      <nav>
+        <Link to="/">Home</Link> | <Link to="/settings">Settings</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home settings={settings} />} />
+        <Route
+          path="/settings"
+          element={<Settings settings={settings} setSettings={setSettings} />}
+        />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>React SPA</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+    <script type="text/babel" src="app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add simple index.html loading React, React Router and Babel from CDNs
- implement app.js with home and user settings pages
- persist user settings in localStorage
- update README with instructions for GitHub Pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841a1bd9a34832ea30534105cb6eeef